### PR TITLE
[codex] Defer launcher ready until initial prompt data settles

### DIFF
--- a/DECISION_JOURNAL.md
+++ b/DECISION_JOURNAL.md
@@ -12,6 +12,7 @@
 - CodeXWeb claimed PR #43 review follow-up comment `4670504519` with claim comment `4673644135`.
 - Scope: keep the PR's mounted + initial data settled design, but make the initial prompt search failure path also release the hidden launcher window so users can see the existing error state.
 - Validation passed in remote sandbox: `npm ci --include=dev --no-audit --no-fund`, `npm run test:unit` (15 passed), `npm run check` (0 errors, 0 warnings), `npm run build`, and `git diff --check`.
+- Additional validation attempt: `npm run tauri build` was blocked by the remote sandbox lacking `cargo` (`cargo metadata` not found); no Tauri/Rust source was changed in this follow-up.
 
 ### 2026-01-22 21:49
 - Checked required project guidance files in this worktree:

--- a/DECISION_JOURNAL.md
+++ b/DECISION_JOURNAL.md
@@ -8,6 +8,11 @@
 
 ## Log
 
+### 2026-06-10 19:21 UTC
+- CodeXWeb claimed PR #43 review follow-up comment `4670504519` with claim comment `4673644135`.
+- Scope: keep the PR's mounted + initial data settled design, but make the initial prompt search failure path also release the hidden launcher window so users can see the existing error state.
+- Validation passed in remote sandbox: `npm ci --include=dev --no-audit --no-fund`, `npm run test:unit` (15 passed), `npm run check` (0 errors, 0 warnings), `npm run build`, and `git diff --check`.
+
 ### 2026-01-22 21:49
 - Checked required project guidance files in this worktree:
   - CLAUDE.md: missing

--- a/prompt-launcher/src/lib/launcherReadyGate.js
+++ b/prompt-launcher/src/lib/launcherReadyGate.js
@@ -1,0 +1,41 @@
+/**
+ * Creates a small gate that keeps the backend window hidden until the launcher
+ * has mounted and the initial prompt search has had a chance to update UI state.
+ *
+ * @param {() => Promise<unknown>} notifyBackendReady
+ * @param {(callback: () => void) => void} [schedule]
+ * @param {(error: unknown) => void} [onError]
+ */
+export function createLauncherReadyGate(
+  notifyBackendReady,
+  schedule = (callback) => setTimeout(callback, 0),
+  onError = () => {}
+) {
+  let mounted = false;
+  let scheduled = false;
+  let notified = false;
+
+  return {
+    markMounted() {
+      mounted = true;
+    },
+
+    scheduleAfterInitialData() {
+      if (!mounted || scheduled || notified) {
+        return;
+      }
+
+      scheduled = true;
+      schedule(() => {
+        void notifyBackendReady()
+          .then(() => {
+            notified = true;
+          })
+          .catch((error) => {
+            scheduled = false;
+            onError(error);
+          });
+      });
+    }
+  };
+}

--- a/prompt-launcher/src/lib/launcherReadyGate.js
+++ b/prompt-launcher/src/lib/launcherReadyGate.js
@@ -39,3 +39,20 @@ export function createLauncherReadyGate(
     }
   };
 }
+
+/**
+ * Treat the first prompt search as settled whether it succeeds or fails so the
+ * launcher can show either results or the existing error state.
+ *
+ * @template T
+ * @param {Promise<T>} initialDataPromise
+ * @param {{ scheduleAfterInitialData: () => void }} gate
+ * @returns {Promise<T>}
+ */
+export async function notifyWhenInitialDataSettles(initialDataPromise, gate) {
+  try {
+    return await initialDataPromise;
+  } finally {
+    gate.scheduleAfterInitialData();
+  }
+}

--- a/prompt-launcher/src/lib/launcherReadyGate.test.js
+++ b/prompt-launcher/src/lib/launcherReadyGate.test.js
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { createLauncherReadyGate } from "./launcherReadyGate.js";
 
-const flushMicrotasks = () => Promise.resolve();
+const flushAsyncHandlers = () => new Promise((resolve) => setImmediate(resolve));
 
 test("does not notify the backend before the frontend is mounted", async () => {
   /** @type {string[]} */
@@ -23,7 +23,7 @@ test("does not notify the backend before the frontend is mounted", async () => {
   assert.equal(scheduled.length, 1);
 
   scheduled[0]();
-  await flushMicrotasks();
+  await flushAsyncHandlers();
   assert.deepEqual(calls, ["frontend_ready"]);
 });
 
@@ -44,7 +44,7 @@ test("coalesces repeated ready requests into one backend notification", async ()
 
   assert.equal(scheduled.length, 1);
   scheduled[0]();
-  await flushMicrotasks();
+  await flushAsyncHandlers();
 
   gate.scheduleAfterInitialData();
   assert.equal(scheduled.length, 1);
@@ -71,7 +71,7 @@ test("allows retry when the backend notification fails", async () => {
   gate.markMounted();
   gate.scheduleAfterInitialData();
   scheduled[0]();
-  await flushMicrotasks();
+  await flushAsyncHandlers();
 
   assert.equal(attempts, 1);
   assert.equal(errors.length, 1);
@@ -79,7 +79,7 @@ test("allows retry when the backend notification fails", async () => {
   gate.scheduleAfterInitialData();
   assert.equal(scheduled.length, 2);
   scheduled[1]();
-  await flushMicrotasks();
+  await flushAsyncHandlers();
 
   assert.equal(attempts, 2);
   assert.equal(errors.length, 1);

--- a/prompt-launcher/src/lib/launcherReadyGate.test.js
+++ b/prompt-launcher/src/lib/launcherReadyGate.test.js
@@ -1,6 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { createLauncherReadyGate } from "./launcherReadyGate.js";
+import {
+  createLauncherReadyGate,
+  notifyWhenInitialDataSettles
+} from "./launcherReadyGate.js";
 
 const flushAsyncHandlers = () => new Promise((resolve) => setImmediate(resolve));
 
@@ -83,4 +86,20 @@ test("allows retry when the backend notification fails", async () => {
 
   assert.equal(attempts, 2);
   assert.equal(errors.length, 1);
+});
+
+test("schedules readiness after initial data loading fails", async () => {
+  const searchError = new Error("search_prompts failed");
+  let scheduled = false;
+
+  await assert.rejects(
+    notifyWhenInitialDataSettles(Promise.reject(searchError), {
+      scheduleAfterInitialData: () => {
+        scheduled = true;
+      }
+    }),
+    searchError
+  );
+
+  assert.equal(scheduled, true);
 });

--- a/prompt-launcher/src/lib/launcherReadyGate.test.js
+++ b/prompt-launcher/src/lib/launcherReadyGate.test.js
@@ -5,7 +5,9 @@ import { createLauncherReadyGate } from "./launcherReadyGate.js";
 const flushMicrotasks = () => Promise.resolve();
 
 test("does not notify the backend before the frontend is mounted", async () => {
+  /** @type {string[]} */
   const calls = [];
+  /** @type {Array<() => void>} */
   const scheduled = [];
   const gate = createLauncherReadyGate(
     async () => calls.push("frontend_ready"),
@@ -26,7 +28,9 @@ test("does not notify the backend before the frontend is mounted", async () => {
 });
 
 test("coalesces repeated ready requests into one backend notification", async () => {
+  /** @type {string[]} */
   const calls = [];
+  /** @type {Array<() => void>} */
   const scheduled = [];
   const gate = createLauncherReadyGate(
     async () => calls.push("frontend_ready"),
@@ -48,7 +52,9 @@ test("coalesces repeated ready requests into one backend notification", async ()
 });
 
 test("allows retry when the backend notification fails", async () => {
+  /** @type {unknown[]} */
   const errors = [];
+  /** @type {Array<() => void>} */
   const scheduled = [];
   let attempts = 0;
   const gate = createLauncherReadyGate(

--- a/prompt-launcher/src/lib/launcherReadyGate.test.js
+++ b/prompt-launcher/src/lib/launcherReadyGate.test.js
@@ -1,0 +1,80 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createLauncherReadyGate } from "./launcherReadyGate.js";
+
+const flushMicrotasks = () => Promise.resolve();
+
+test("does not notify the backend before the frontend is mounted", async () => {
+  const calls = [];
+  const scheduled = [];
+  const gate = createLauncherReadyGate(
+    async () => calls.push("frontend_ready"),
+    (callback) => scheduled.push(callback)
+  );
+
+  gate.scheduleAfterInitialData();
+  assert.equal(scheduled.length, 0);
+  assert.deepEqual(calls, []);
+
+  gate.markMounted();
+  gate.scheduleAfterInitialData();
+  assert.equal(scheduled.length, 1);
+
+  scheduled[0]();
+  await flushMicrotasks();
+  assert.deepEqual(calls, ["frontend_ready"]);
+});
+
+test("coalesces repeated ready requests into one backend notification", async () => {
+  const calls = [];
+  const scheduled = [];
+  const gate = createLauncherReadyGate(
+    async () => calls.push("frontend_ready"),
+    (callback) => scheduled.push(callback)
+  );
+
+  gate.markMounted();
+  gate.scheduleAfterInitialData();
+  gate.scheduleAfterInitialData();
+  gate.scheduleAfterInitialData();
+
+  assert.equal(scheduled.length, 1);
+  scheduled[0]();
+  await flushMicrotasks();
+
+  gate.scheduleAfterInitialData();
+  assert.equal(scheduled.length, 1);
+  assert.deepEqual(calls, ["frontend_ready"]);
+});
+
+test("allows retry when the backend notification fails", async () => {
+  const errors = [];
+  const scheduled = [];
+  let attempts = 0;
+  const gate = createLauncherReadyGate(
+    async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        throw new Error("temporary failure");
+      }
+    },
+    (callback) => scheduled.push(callback),
+    (error) => errors.push(error)
+  );
+
+  gate.markMounted();
+  gate.scheduleAfterInitialData();
+  scheduled[0]();
+  await flushMicrotasks();
+
+  assert.equal(attempts, 1);
+  assert.equal(errors.length, 1);
+
+  gate.scheduleAfterInitialData();
+  assert.equal(scheduled.length, 2);
+  scheduled[1]();
+  await flushMicrotasks();
+
+  assert.equal(attempts, 2);
+  assert.equal(errors.length, 1);
+});

--- a/prompt-launcher/src/lib/tauriClient.ts
+++ b/prompt-launcher/src/lib/tauriClient.ts
@@ -1,5 +1,8 @@
 import { invoke } from "@tauri-apps/api/core";
-import { createLauncherReadyGate } from "./launcherReadyGate.js";
+import {
+  createLauncherReadyGate,
+  notifyWhenInitialDataSettles
+} from "./launcherReadyGate.js";
 import type { AppConfig, PromptEntry, RecentState } from "./types";
 
 const launcherReadyGate = createLauncherReadyGate(
@@ -12,13 +15,14 @@ export const tauriClient = {
   getConfig: () => invoke<AppConfig>("get_config"),
   listPrompts: () => invoke<PromptEntry[]>("list_prompts"),
   searchPrompts: async (query: string, limit: number, favoritesOnly: boolean) => {
-    const prompts = await invoke<PromptEntry[]>("search_prompts", {
-      query,
-      limit,
-      favoritesOnly
-    });
-    launcherReadyGate.scheduleAfterInitialData();
-    return prompts;
+    return notifyWhenInitialDataSettles(
+      invoke<PromptEntry[]>("search_prompts", {
+        query,
+        limit,
+        favoritesOnly
+      }),
+      launcherReadyGate
+    );
   },
   setPromptsDir: (path: string) =>
     invoke<PromptEntry[]>("set_prompts_dir", { path }),

--- a/prompt-launcher/src/lib/tauriClient.ts
+++ b/prompt-launcher/src/lib/tauriClient.ts
@@ -1,11 +1,25 @@
 import { invoke } from "@tauri-apps/api/core";
+import { createLauncherReadyGate } from "./launcherReadyGate.js";
 import type { AppConfig, PromptEntry, RecentState } from "./types";
+
+const launcherReadyGate = createLauncherReadyGate(
+  () => invoke("frontend_ready"),
+  (callback) => setTimeout(callback, 0),
+  (error) => console.warn("[frontend_ready] Failed to notify backend", error)
+);
 
 export const tauriClient = {
   getConfig: () => invoke<AppConfig>("get_config"),
   listPrompts: () => invoke<PromptEntry[]>("list_prompts"),
-  searchPrompts: (query: string, limit: number, favoritesOnly: boolean) =>
-    invoke<PromptEntry[]>("search_prompts", { query, limit, favoritesOnly }),
+  searchPrompts: async (query: string, limit: number, favoritesOnly: boolean) => {
+    const prompts = await invoke<PromptEntry[]>("search_prompts", {
+      query,
+      limit,
+      favoritesOnly
+    });
+    launcherReadyGate.scheduleAfterInitialData();
+    return prompts;
+  },
   setPromptsDir: (path: string) =>
     invoke<PromptEntry[]>("set_prompts_dir", { path }),
   createPromptFile: (name: string) =>
@@ -38,5 +52,7 @@ export const tauriClient = {
   captureActiveWindow: () => invoke("capture_active_window"),
   focusLastWindow: (autoPaste: boolean) =>
     invoke("focus_last_window", { autoPaste }),
-  frontendReady: () => invoke("frontend_ready")
+  frontendReady: async () => {
+    launcherReadyGate.markMounted();
+  }
 };


### PR DESCRIPTION
## Summary

Fix the Windows cold-launch blank/white launcher state by delaying the backend `frontend_ready` notification until after the first prompt search has completed and the Svelte page has a chance to write initial result state.

## Root Cause

The route currently calls `frontendReady()` as soon as the component mounts. The backend treats that as permission to show the hidden Tauri window, even though config loading, prompt loading, and the first search result refresh still happen afterward. On Windows, the transparent hidden window can therefore be shown during a half-initialized frame; toggling Settings later forces another render/resize, which makes the launcher appear normal.

## Changes

- Added a small launcher ready gate that only notifies the backend after the frontend has mounted and initial data has returned.
- Updated `tauriClient.searchPrompts` to schedule backend readiness after the first search result response.
- Kept backend notification idempotent and retryable if the notification fails.
- Added Node unit tests for the ready gate behavior.

## Validation

- Added `prompt-launcher/src/lib/launcherReadyGate.test.js` for the new readiness gate.
- Expected CI path: `npm run test:unit`, `npm run check`, frontend build, and Tauri build on PR.
- Local checkout/test execution was not available in this container because direct GitHub clone/download requests are blocked, so the PR CI should be used as the authoritative run.